### PR TITLE
Parse string coords to double in destination

### DIFF
--- a/src/destination.cpp
+++ b/src/destination.cpp
@@ -15,8 +15,11 @@ std::string destination(std::string from, double distance, double bearing, std::
   double degrees2radians = pie / 180;
   double radians2degrees = 180 / pie;
   std::string coordinates1 = get_coords(from);
-  double longitude1 = degrees2radians * coordinates1[0];
-  double latitude1 = degrees2radians * coordinates1[1];
+  auto coords = json::parse(coordinates1);
+
+  double longitude1 = degrees2radians * std::stod(coords[0].dump());
+  double latitude1 = degrees2radians * std::stod(coords[1].dump());
+
   double bearing_rad = degrees2radians * bearing;
 
   double radians = distanceToRadians(distance, units);


### PR DESCRIPTION
Fix `destination` so that coordinates are parsed correctly. Initially were just a string. I poked around in `bearing.cpp` and figured it out...

Fixes #7 because `destination` is used to calculate the distance along the line in `geo_along`.

``` r
library(geoops)

point1 <- '{
"type": "Feature",
"properties": {
"marker-color": "#f00"
},
"geometry": {
"type": "Point",
"coordinates": [-77.029609, 38.881946]
}
}'
geo_destination(point1, 0.1, 90, "kilometres")
#> [1] "{\"geometry\":{\"coordinates\":[-77.028454,38.881946],\"type\":\"Point\"},\"properties\":{},\"type\":\"Feature\"}"

line <- '{
"type": "Feature",
"properties": {},
"geometry": {
"type": "LineString",
"coordinates": [
[-77.031669, 38.878605],
[-77.029609, 38.881946],
[-77.020339, 38.884084],
[-77.025661, 38.885821],
[-77.021884, 38.889563],
[-77.019824, 38.892368]
]
}
}'
geo_along(line, 1, "kilometres")
#> [1] "{\"geometry\":{\"coordinates\":[-77.0231,38.883447],\"type\":\"Point\"},\"properties\":{},\"type\":\"Feature\"}"
```

